### PR TITLE
Be more careful when decoding AdvertisingData

### DIFF
--- a/hat-mibcs/src/bluetooth/advertising_data.rs
+++ b/hat-mibcs/src/bluetooth/advertising_data.rs
@@ -18,7 +18,7 @@ impl<'t> AdvertisingData<'t> {
     }
 }
 
-pub fn parse_ad(data: &[u8]) -> IntoIter<AdvertisingData> {
+pub fn parse_ad(data: &[u8]) -> Option<IntoIter<AdvertisingData>> {
     // decode Advertising Data.
     // 1st byte = length of the element, excluding the length byte itself
     // 2nd AD type = specifies what data is included in the element
@@ -27,21 +27,62 @@ pub fn parse_ad(data: &[u8]) -> IntoIter<AdvertisingData> {
     let mut vec = Vec::new();
 
     while idx < data.len() {
+        if idx >= data.len() {
+            return None
+        }
         let ad_length = data[idx] as usize;
         idx += 1;
+        if idx >= data.len() {
+            return None
+        }
+        if ad_length == 0 {
+            return None
+        }
         let ad_type = data[idx];
         idx += 1;
+        if idx > data.len() || idx+ad_length-1 > data.len() {
+            return None
+        }
         let ad_data = &data[idx..idx + ad_length - 1];
         idx += ad_length - 1;
 
+        let adtype = adtype::Adtype::from_u8(ad_type)?;
+
         let ad = AdvertisingData {
             length: ad_length,
-            adtype: adtype::Adtype::from_u8(ad_type).unwrap(),
+            adtype: adtype,
             data: ad_data,
         };
 
         vec.push(ad);
     }
 
-    vec.into_iter()
+    Some(vec.into_iter())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn good_data_test() {
+        let data = [
+            0x03, 0x03, 0x9f, 0xfe, 0x17, 0x16, 0x9f, 0xfe, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        ];
+
+        parse_ad(&data);
+    }
+
+    #[test]
+    fn bad_data_test() {
+        // This is just bad data, so we can't parse it properly
+        let data = [
+            0x02, 0x01, 0x06, 0x03, 0x02, 0xf0, 0x18, 0x11, 0x06, 0xf2, 0xc3, 0xf0, 0xae, 0xa9,
+            0xfa, 0x15, 0x8c, 0x9d, 0x49, 0xae, 0x73, 0x71, 0x0a, 0x81, 0xe7, 0x02, 0x0a, 0x04,
+            0x00, 0x00, 0x00
+        ];
+
+        assert!(parse_ad(&data).is_none())
+    }
 }

--- a/hat-mibcs/src/main.rs
+++ b/hat-mibcs/src/main.rs
@@ -89,7 +89,7 @@ mod test {
         ];
         let scale_data = WeightData::parse(
             "FF:FF:FF:FF:FF:FF",
-            bluetooth::advertising_data::parse_ad(&data).as_slice(),
+            bluetooth::advertising_data::parse_ad(&data).unwrap().as_slice(),
         )
         .unwrap();
         scale_data.dump();
@@ -110,7 +110,7 @@ mod test {
         ];
         let scale_data = WeightData::parse(
             "FF:FF:FF:FF:FF:FF",
-            bluetooth::advertising_data::parse_ad(&data).as_slice(),
+            bluetooth::advertising_data::parse_ad(&data).unwrap().as_slice(),
         )
         .unwrap();
         scale_data.dump();
@@ -127,7 +127,7 @@ mod test {
         ];
         let scale_data = WeightData::parse(
             "FF:FF:FF:FF:FF:FF",
-            bluetooth::advertising_data::parse_ad(&data).as_slice(),
+            bluetooth::advertising_data::parse_ad(&data).unwrap().as_slice(),
         )
         .unwrap();
         scale_data.dump();

--- a/hat-mibcs/src/mibcs/scanner.rs
+++ b/hat-mibcs/src/mibcs/scanner.rs
@@ -99,10 +99,13 @@ impl<'t> MIBCSScanner<'t> {
                 break;
             }
 
-            let elapsed = now.elapsed()?;
 
-            if self.cli.duration > 0 && elapsed.as_secs() > self.cli.duration {
-                break;
+            if self.cli.duration > 0 {
+                let elapsed = now.elapsed()?;
+
+                if elapsed.as_secs() > self.cli.duration {
+                    break;
+                }
             }
         }
 
@@ -119,6 +122,12 @@ impl<'t> MIBCSScanner<'t> {
         }
 
         let ads = bluetooth::advertising_data::parse_ad(&data.buffer);
+
+        if ads.is_none() {
+            return Ok(false);
+        }
+
+        let ads = ads.unwrap();
 
         if self.cli.debug {
             for ad in ads.as_slice() {


### PR DESCRIPTION
Fixes errors like:
thread 'main' panicked at 'slice index starts at 30 but ends at 29',
src/libcore/slice/mod.rs:2419:5
note: Run with `RUST_BACKTRACE=1` environment variable to display a
backtrace.