### PR TITLE
Improves error handling. Now btlepasvscan_open can fail, but yet return ctx

### DIFF
--- a/btlepasvscan-sys/c/blescan.c
+++ b/btlepasvscan-sys/c/blescan.c
@@ -1,6 +1,7 @@
 #include <signal.h>
 
 #include "btlepasvscan.h"
+#include <errno.h>
 
 static int stop_scan = 0;
 
@@ -9,17 +10,25 @@ void sigint_handler(int sig) {
 }
 
 int main(int argc, char **argv) {
-  signal(SIGINT, sigint_handler); 
+  signal(SIGINT, sigint_handler);
 
   btlepasvscan_ctx* ctx = btlepasvscan_open();
 
   if(ctx) {
-    while(!stop_scan && btlepasvscan_read(ctx)) {
-      printf("* %s [ ", ctx->address);
-      for (int i = 0; i < ctx->length; i++) {
-        printf("0x%02X ", ctx->data[i]);
+    puts("Got context");
+
+    if(ctx->error == BTLEPASVSCAN_OK) {
+      while(!stop_scan && btlepasvscan_read(ctx)) {
+        printf("* %s [ ", ctx->address);
+        for (int i = 0; i < ctx->length; i++) {
+          printf("0x%02X ", ctx->data[i]);
+        }
+        puts("]");
       }
-      puts("]");
+    }
+    else {
+      printf("btlepasvscan-error: %d, errno: %d\n", ctx->error, errno);
+      perror("btlepasvscan");
     }
     btlepasvscan_close(ctx);
     ctx = NULL;

--- a/btlepasvscan-sys/c/btlepasvscan.h
+++ b/btlepasvscan-sys/c/btlepasvscan.h
@@ -10,6 +10,7 @@
 #error Unexpected HCI_MAX_FRAME_SIZE size
 #endif
 
+const uint8_t BTLEPASVSCAN_OK;
 const uint8_t BTLEPASVSCAN_ERR_RECV;
 const uint8_t BTLEPASVSCAN_ERR_BAD_DATA;
 const uint8_t BTLEPASVSCAN_ERR_SETSOCKOPT;
@@ -17,6 +18,8 @@ const uint8_t BTLEPASVSCAN_ERR_BIND;
 const uint8_t BTLEPASVSCAN_ERR_HCI_LE_SET_SCAN_PARAMETERS;
 const uint8_t BTLEPASVSCAN_ERR_HCI_LE_SET_SCAN_ENABLE;
 const uint8_t BTLEPASVSCAN_ERR_HCI_LE_SET_SCAN_DISABLE;
+const uint8_t BTLEPASVSCAN_ERR_OPEN;
+
 
 typedef struct {
   int sock;
@@ -25,6 +28,7 @@ typedef struct {
   uint8_t* data;
   uint32_t length;
   uint8_t error;
+  uint8_t scan; // true/false if blescan was activated
 } btlepasvscan_ctx;
 
 btlepasvscan_ctx* btlepasvscan_open();

--- a/btlepasvscan-sys/src/lib.rs
+++ b/btlepasvscan-sys/src/lib.rs
@@ -11,6 +11,7 @@ pub struct btlepasvscan_ctx {
     pub data: *mut u8,
     pub length: u32,
     pub error: u8,
+    pub scan: u8,
 }
 #[test]
 fn bindgen_test_layout_btlepasvscan_ctx() {
@@ -82,6 +83,16 @@ fn bindgen_test_layout_btlepasvscan_ctx() {
             stringify!(btlepasvscan_ctx),
             "::",
             stringify!(error)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<btlepasvscan_ctx>())).scan as *const _ as usize },
+        1541usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(btlepasvscan_ctx),
+            "::",
+            stringify!(scan)
         )
     );
 }

--- a/btlepasvscan/src/lib.rs
+++ b/btlepasvscan/src/lib.rs
@@ -12,6 +12,7 @@ pub enum Error {
     HciLeSetScanParameters,
     HciLeSetScanEnable,
     HciLeSetScanDisable,
+    Open,
 }
 
 impl ToString for Error {
@@ -37,7 +38,8 @@ impl ToString for Error {
                 "hci_le_set_scan_disable() ".to_string()
                     + &std::io::Error::last_os_error().to_string()
             }
-            Error::BadData => "Received unexpected BTLE data".to_string(),
+            Error::BadData => "Received unexpected BTLE data ".to_string(),
+            Error::Open => "open() ".to_string(),
         }
     }
 }
@@ -66,7 +68,18 @@ impl BtlePasvScan {
         if context.is_null() {
             Err(Error::Context)
         } else {
-            Ok(BtlePasvScan { context })
+            match unsafe { (*context).error } {
+                0 => Ok(BtlePasvScan { context }),
+                1 => Err(Error::Recv),
+                2 => Err(Error::BadData),
+                3 => Err(Error::SetSockOpt),
+                4 => Err(Error::Bind),
+                5 => Err(Error::HciLeSetScanParameters),
+                6 => Err(Error::HciLeSetScanEnable),
+                7 => Err(Error::HciLeSetScanDisable),
+                8 => Err(Error::Open),
+                _ => Err(Error::Context)
+            }
         }
     }
 


### PR DESCRIPTION
ctx->error will tell you what happened. Also utilize ctx->error in rust
crate